### PR TITLE
Rename `/symfony.phar` to `symfony`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM php:5-cli
 RUN curl -LsS http://symfony.com/installer > /usr/local/bin/symfony \
  && chmod +x /usr/local/bin/symfony
 
+RUN echo "date.timezone = Europe/Paris" >> /usr/local/etc/php/conf.d/symfony.ini
+
 VOLUME ["/src"]
 WORKDIR /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:5-cli
 
+RUN curl -LsS http://symfony.com/installer > /usr/local/bin/symfony \
+ && chmod +x /usr/local/bin/symfony
+
 VOLUME ["/src"]
 WORKDIR /src
 
-RUN curl -LsS http://symfony.com/installer > /symfony.phar
-RUN chmod +x /symfony.phar
-
-ENTRYPOINT ["/symfony.phar"]
+ENTRYPOINT ["symfony"]


### PR DESCRIPTION
Actualy the readme recommends to use an alias named `symfony` But the application's helper display messages starting by `/symfony.phar`
